### PR TITLE
Register drive mapping task as SYSTEM and secure extension settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -213,8 +213,11 @@ resource "azurerm_virtual_machine_extension" "map_data_drive" {
   type_handler_version = "1.10"
 
   settings = jsonencode({
-    fileUris         = ["${path.module}/scripts/map-drive.ps1"]
-    commandToExecute = "powershell -ExecutionPolicy Bypass -File map-drive.ps1 -StorageAccountName ${azurerm_storage_account.sa.name} -ShareName ${azurerm_storage_share.data.name} -AccountKey ${azurerm_storage_account.sa.primary_access_key} -AdminUser ${var.admin_username} -AdminPassword ${var.admin_password}"
+    fileUris = ["${path.module}/scripts/map-drive.ps1"]
+  })
+
+  protected_settings = jsonencode({
+    commandToExecute = "powershell -ExecutionPolicy Bypass -File map-drive.ps1 -StorageAccountName ${azurerm_storage_account.sa.name} -ShareName ${azurerm_storage_share.data.name} -AccountKey ${azurerm_storage_account.sa.primary_access_key} -DriveLetter S"
   })
 
   depends_on = [

--- a/scripts/map-drive.ps1
+++ b/scripts/map-drive.ps1
@@ -2,9 +2,7 @@ param(
     [string]$StorageAccountName,
     [string]$ShareName,
     [string]$AccountKey,
-    [string]$DriveLetter = "S",
-    [string]$AdminUser,
-    [string]$AdminPassword
+    [string]$DriveLetter = "S"
 )
 
 $target = "$StorageAccountName.file.core.windows.net"
@@ -14,4 +12,4 @@ $sharePath = "\\$target\$ShareName"
 cmdkey /add:$target /user:$user /pass:$AccountKey
 New-PSDrive -Name $DriveLetter -PSProvider FileSystem -Root $sharePath -Persist
 
-schtasks.exe /Create /TN MapDataDrive /TR "powershell -ExecutionPolicy Bypass -File C:\map-drive.ps1 -StorageAccountName $StorageAccountName -ShareName $ShareName -AccountKey $AccountKey -DriveLetter $DriveLetter -AdminUser $AdminUser -AdminPassword $AdminPassword" /SC ONLOGON /RL HIGHEST /RU $AdminUser /RP $AdminPassword /F
+schtasks.exe /Create /TN MapDataDrive /TR "powershell -ExecutionPolicy Bypass -File C:\\map-drive.ps1 -StorageAccountName $StorageAccountName -ShareName $ShareName -AccountKey $AccountKey -DriveLetter $DriveLetter" /SC ONLOGON /RL HIGHEST /RU SYSTEM /F


### PR DESCRIPTION
## Summary
- Register scheduled task to remap storage share as SYSTEM to avoid embedding admin creds
- Move custom script command into protected settings so account key isn't logged

## Testing
- `terraform fmt`
- `terraform init` *(fails: Failed to query available provider packages: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bfac4c6483318c28c7809c4eda62